### PR TITLE
use slightly newer dependencies (which are still available on Maven)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ organization := "com.worldwidemann"
 homepage := Some(url("https://github.com/p-e-w/sequencer"))
 
 libraryDependencies ++= Seq(
-	"com.github.scopt" %% "scopt" % "3.3.0",
+	"com.github.scopt" %% "scopt" % "3.5.0",
 	"log4j" % "log4j" % "1.2.17",
-	"axelclk" % "symja" % "2015-02-08" from "https://bitbucket.org/axelclk/symja_android_library/downloads/symja-2015-02-08.jar"
+	"axelclk" % "symja" % "2015-02-08" from "https://bitbucket.org/axelclk/symja_android_library/downloads/symja-2015-02-20.jar"
 )
 
 resolvers += Resolver.sonatypeRepo("public")

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
 


### PR DESCRIPTION
The current dependencies were no longer available on Maven – these are just minimal changes to enable build. (by the way, the binary from Releases page no longer works on Java 11 - rebuilding from sources on recent JDK fixes this)